### PR TITLE
Fix for websites having a global variable named "exports"

### DIFF
--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -18,7 +18,7 @@ https://github.com/mroderick/PubSubJS
 	'use strict';
 
 	// CommonJS
-	if (typeof exports === 'object'){
+	if (typeof exports === 'object' && module){
 		module.exports = factory();
 
 	// AMD


### PR DESCRIPTION
SnapEngage sets a global variable named "exports" to the window object. On pages like these, PubSub breaks with error
`Uncaught ReferenceError: module is not defined`.
