### PR TITLE
Allow passing the message identifier to the unsubscribe method

### DIFF
--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -156,14 +156,16 @@ https://github.com/mroderick/PubSubJS
             result = false,
             i;
 
-        for ( i = messages[message].length-1 ; i >= 0; i-- ){
-            if ( messages[message][i][key] === tokenOrFunction ){
-                messages[message].splice( i, 1 );
-                result = succesfulReturnValue;
+        if (messages[message]) {
+            for ( i = messages[message].length-1 ; i >= 0; i-- ){
+                if ( messages[message][i][key] === tokenOrFunction ){
+                    messages[message].splice( i, 1 );
+                    result = succesfulReturnValue;
 
-                // tokens are unique, so we can just return here
-                if ( isToken ){
-                    return result;
+                    // tokens are unique, so we can just return here
+                    if ( isToken ){
+                        return result;
+                    }
                 }
             }
         }

--- a/test/test-unsubscribe.js
+++ b/test/test-unsubscribe.js
@@ -73,6 +73,39 @@
 			assert.equals( PubSub.unsubscribe( func ), false );
 		},
 
+		"with message and function arguments should return true when succesful" : function(){
+			var func = function(){},
+				message = TestHelper.getUniqueString(),
+				result;
+
+			PubSub.subscribe( message, func);
+			result = PubSub.unsubscribe( message, func );
+
+			assert.equals( result, true );
+		},
+
+		"with message and function arguments should return false when unsuccesful" : function(){
+			var func = function(){},
+				message = TestHelper.getUniqueString(),
+				unknownToken = 'my unknown token',
+				result = PubSub.unsubscribe( message, unknownToken );
+
+			// first, let's try a completely unknown token
+
+			assert.equals( result, false );
+
+			// now let's try unsubscribing the same method twice
+			PubSub.subscribe( message, func );
+			PubSub.subscribe( message, func );
+			PubSub.subscribe( message, func );
+
+			// unsubscribe once, this should remove all subscriptions for message
+			PubSub.unsubscribe( message, func );
+
+			// unsubscribe again
+			assert.equals( PubSub.unsubscribe( message, func ), false );
+		},
+
 		'must not throw exception when unsubscribing as part of publishing' : function(){
 			refute.exception(function(){
 				var topic = TestHelper.getUniqueString(),


### PR DESCRIPTION
Allows the message to be passed as the first argument to only unsubscribe a given function from a specific message.

It's really more of a nice to have to stop a person from having to keep a variable with the token to unsubscribe while still allowing to unsubscribe a method from a given message that one may want to re-use in a different message.
