### PR TITLE
Allow unsubscribe to be called on a listener

### DIFF
--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -68,7 +68,7 @@ https://github.com/mroderick/PubSubJS
 
         // Ensure that all subscribers to the event get the message
         // even if one is unsubscribed when responding to the message
-        subscribers = subscribers.splice(0);
+        subscribers = subscribers.slice(0);
 
 		for ( i = 0; i < subscribers.length; i++ ){
 			callSubscriber( subscribers[i].func, originalMessage, data );


### PR DESCRIPTION
I found a small issue related to issue #26 where calling unsubscribe on a listener would prevent some of the registered listeners from getting the event.

I found a way to fix this by storing a copy to use during delivery instead of iterating over the array of listeners that can change at any time.

This allows a person to setup a listener that only fires once for example.
