### PR TITLE
Fix for topic hierarchy

### DIFF
--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -94,17 +94,17 @@ https://github.com/mroderick/PubSubJS
 	function messageHasSubscribers( message ){
         var topic = String( message ),
             found = messages.hasOwnProperty( topic ) && messages[topic].length,
-            position = topic.lastIndexOf( PubSub.delimeter );
+            position = topic.lastIndexOf( '.' );
 
         while ( !found && position !== -1 ){
             topic = topic.substr( 0, position );
-            position = topic.lastIndexOf(PubSub.delimeter);
+            position = topic.lastIndexOf( '.' );
             found = messages.hasOwnProperty( topic ) && messages[topic].length;
         }
 
         return found;
     }
-        
+
 	function publish( message, data, sync, immediateExceptions ){
 		var deliver = createDeliveryFunction( message, data, immediateExceptions ),
 			hasSubscribers = messageHasSubscribers( message );


### PR DESCRIPTION
If top level topic is empty (all subscribers were unsubscribed), `messages[topic]` is empty `Array`. So function `messageHasSubscribers` will return false, because topic found and have 0 subscribers, so here will not be check for lower topic levels.

Steps to reproduce:
- add high level topic subscriber (`'file:created:test'`)
- add low level topic subscriber (`'file:created'`)
- remove high level topic subscriber (`'file:created:test'`)
- publish high level event (`'file:created:test'`)
