### PR TITLE
Make tests compatible with BusterJS 0.7.4+

### DIFF
--- a/test/helper.js
+++ b/test/helper.js
@@ -2,7 +2,7 @@
 /*global
 	exports,
 	module,
-	assert,
+    buster,
 	define,
 	window
 */
@@ -24,7 +24,8 @@
 
 	'use strict';
 
-	var TestHelper = {};
+	var TestHelper = {},
+        assert = buster.assert;
 
 	// helps us make sure that the order of the tests have no impact on their succes
 	function getUniqueString(){

--- a/test/test-bug-9.js
+++ b/test/test-bug-9.js
@@ -2,7 +2,6 @@
 /*global
 	PubSub,
 	buster,
-	assert,
 	require,
 	sinon,
 	done
@@ -10,7 +9,8 @@
 (function( global ){
 	"use strict";
 
-	var PubSub = global.PubSub || require("../src/pubsub");
+	var PubSub = global.PubSub || require("../src/pubsub"),
+        assert = buster.assert;
 
 	/**
 	 *	This is a test proving that bug 9 has been fixed.

--- a/test/test-hierarchical-addressing.js
+++ b/test/test-hierarchical-addressing.js
@@ -2,7 +2,6 @@
 /*global
 	PubSub,
 	buster,
-	assert,
 	require,
 	sinon
 */
@@ -10,7 +9,8 @@
 	"use strict";
 	
 	var PubSub = global.PubSub || require("../src/pubsub"),
-		TestHelper = global.TestHelper || require("../test/helper");
+		TestHelper = global.TestHelper || require("../test/helper"),
+        assert = buster.assert;
 
 	buster.testCase( "Hierarchical addressing", {
 

--- a/test/test-jquery-integration.js
+++ b/test/test-jquery-integration.js
@@ -2,7 +2,6 @@
 /*global
 	PubSub,
 	buster,
-	assert,
 	require,
 	sinon
 */
@@ -11,7 +10,8 @@
 	
 	var $ = global.jQuery,
 		PubSub = global.PubSub || require("../src/pubsub"),
-		TestHelper = global.TestHelper || require("../test/helper");
+		TestHelper = global.TestHelper || require("../test/helper"),
+        assert = buster.assert;
 
 	buster.testCase( "jQuery integration", {
 

--- a/test/test-publish.js
+++ b/test/test-publish.js
@@ -2,8 +2,6 @@
 /*global
 	PubSub,
 	buster,
-	assert,
-	refute,
 	require,
 	sinon
 */
@@ -11,7 +9,9 @@
 	"use strict";
 
 	var PubSub = global.PubSub || require("../src/pubsub"),
-		TestHelper = global.TestHelper || require("../test/helper");
+		TestHelper = global.TestHelper || require("../test/helper"),
+        assert = buster.assert,
+        refute = buster.refute;
 
 	buster.testCase( "publish method", {
 

--- a/test/test-subscribe.js
+++ b/test/test-subscribe.js
@@ -2,8 +2,6 @@
 /*global
 	PubSub,
 	buster,
-	assert,
-	refute,
 	require,
 	sinon
 */
@@ -11,7 +9,9 @@
 	"use strict";
 	
 	var PubSub = global.PubSub || require("../src/pubsub"),
-		TestHelper = global.TestHelper || require("../test/helper");
+		TestHelper = global.TestHelper || require("../test/helper"),
+        assert = buster.assert,
+        refute = buster.refute;
 
 	buster.testCase( "subscribe method", {
 

--- a/test/test-unsubscribe.js
+++ b/test/test-unsubscribe.js
@@ -2,8 +2,6 @@
 /*global
 	PubSub,
 	buster,
-	assert,
-	refute,
 	require,
 	sinon
 */
@@ -11,7 +9,9 @@
 	"use strict";
 
 	var PubSub = global.PubSub || require("../src/pubsub"),
-		TestHelper = global.TestHelper || require("../test/helper");
+		TestHelper = global.TestHelper || require("../test/helper"),
+        assert = buster.assert,
+        refute = buster.refute;
 
 	buster.testCase( "unsubscribe method", {
 


### PR DESCRIPTION
As of BusterJS 0.7.4 assert, refute and expect are no longer global which
breaks the test suite. Using buster.assert, buster.refute and buster.expect
solves the issue.
