### PR TITLE
Fix check for a global variable "module"

### DIFF
--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -17,7 +17,7 @@ https://github.com/mroderick/PubSubJS
 	'use strict';
 
 	// CommonJS
-	if (typeof exports === 'object' && module){
+	if (typeof exports === 'object' && typeof module !== "undefined"){
 		module.exports = factory();
 
 	// AMD


### PR DESCRIPTION
The simple check for module assumes that a global module variable exists, which is not the case if the browser just has an global exports variable and not a global module variable

also the tests on master currently fail (at least for me locally)
