### PR TITLE
Fix CommonJS issues for contexts without `module` global

### DIFF
--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -18,9 +18,7 @@ https://github.com/mroderick/PubSubJS
 
     if (typeof define === 'function' && define.amd){
         // AMD. Register as an anonymous module.
-        define(['exports'], function (exports, b){
-            factory((root.PubSub = exports), b);
-        });
+        define(['exports'], factory);
 
     } else if (typeof exports === 'object'){
         // CommonJS


### PR DESCRIPTION
This pull request fixes issues #49 and #51 in CommonJS contexts that doesn't provide the `module` global by implementing a slightly tweaked version of https://github.com/umdjs/umd/blob/master/commonjsStrictGlobal.js

The adjustments made are just to pass in the expected `root` to still allow the jQuery version to work.
