### PR TITLE
Tidy Gruntfile.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,29 +1,9 @@
-/*jslint white:true*/
-/*global
-	module
-*/
 module.exports = function(grunt) {
 
 	'use strict';
 
 	// Project configuration.
 	grunt.initConfig({
-		jslint: {
-			files: [
-				'src/**/*.js',
-				'test/**/*.js'
-			],
-
-			exclude: [],
-
-			options: {
-				junit: 'out/junit.xml', // write the output to a JUnit XML
-				log: 'out/lint.log',
-				jslintXml: 'out/jslint_xml.xml',
-				errorsOnly: true // only display errors
-			}
-		},
-
 		buster: {
 			test: {
 				config: 'test/buster.js'


### PR DESCRIPTION
Since we're running JSLint from `npm run`, we no longer need to have
JSLint configuration in `Gruntfile.js`