### PR TITLE
Bugfix/immediate exceptions not working with namespaces

### DIFF
--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -88,7 +88,7 @@ https://github.com/mroderick/PubSubJS
 			while( position !== -1 ){
 				topic = topic.substr( 0, position );
 				position = topic.lastIndexOf('.');
-				deliverMessage( message, topic, data );
+				deliverMessage( message, topic, data, immediateExceptions );
 			}
 		};
 	}

--- a/test/test-publish.js
+++ b/test/test-publish.js
@@ -160,6 +160,27 @@
 			delete PubSub.immediateExceptions;
 		},
 
+		"publish method should fail immediately on exceptions in namespaces when immediateExceptions is true" : function(){
+			var func1 = function(){
+					throw('some error');
+				},
+				spy1 = this.spy();
+
+			PubSub.subscribe( 'buy', func1 );
+			PubSub.subscribe( 'buy', spy1 );
+
+			PubSub.immediateExceptions = true;
+
+			assert.exception( function(){
+				PubSub.publishSync( 'buy.tomatoes', 'some data' );
+			});
+
+			refute( spy1.called );
+
+			// make sure we restore PubSub to it's original state
+			delete PubSub.immediateExceptions;
+		},
+
 		"publish should call all subscribers, even when there are unsubscriptions within" : function(done){
 			var topic = TestHelper.getUniqueString(),
 				spy1 = this.spy(),


### PR DESCRIPTION
This PR fixes a bug with immediate exceptions not being thrown if they come from handlers subscribed to namespaces of the topic being published (subscribe: 'buy' vs publish: 'buy.tomatoes'). The fix is pretty trivial.