### PR TITLE
fix(parent_topic): Be able to unsubscribe all childs from giving a paren...

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ PubSub.subscribe('a.b.c', myFunc3);
 PubSub.unsubscribe('a.b');
 // no further notications for 'a.b' and 'a.b.c' topics
 // notifications for 'a' will still get published
+
+PubSub.unsubscribe('a.b', true);
+// same as previous example but your removing all subscriptions
+// of the children topics
 ```
 
 ### Clear all subscriptions

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -122,11 +122,11 @@ https://github.com/mroderick/PubSubJS
 		}
 		return true;
 	}
-  
+
   /**
    * Decides if topic string has childs in messages
-   * @param  {String}  topic 
-   * @return {Boolean}      
+   * @param  {String}  topic
+   * @return {Boolean}
    */
 	function isParentTopic (topic){
 		var m, reg = new RegExp("^" + topic + "\\.");
@@ -197,7 +197,7 @@ https://github.com/mroderick/PubSubJS
 	/*Public: Clear subscriptions by the topic
 	*/
 	PubSub.clearSubscriptions = function clearSubscriptions(topic){
-		var m; 
+		var m;
 		for (m in messages){
 			if (messages.hasOwnProperty(m) && m.indexOf(topic) === 0){
 				delete messages[m];
@@ -223,11 +223,11 @@ https://github.com/mroderick/PubSubJS
 	 *
 	 *		// Example 3 - unsubscribing a topic
 	 *		PubSub.unsubscribe('mytopic');
-	 *		
+	 *
 	 *		// Example 4 - unsubscribing all children of a parent topic
-	 *		PubSub.unsubscribe('mytopic');
+	 *		PubSub.unsubscribe('mytopic', true);
 	 */
-	PubSub.unsubscribe = function(value){
+	PubSub.unsubscribe = function(value, deep){
 		var isTopic    = typeof value === 'string' && messages.hasOwnProperty(value),
 			isParent = typeof value === 'string' && isParentTopic(value),
 			isToken    = !isTopic && typeof value === 'string',
@@ -235,7 +235,7 @@ https://github.com/mroderick/PubSubJS
 			result = false,
 			m, message, t;
 
-		if (isParent) {
+		if (isParent && !!deep) {
 			for ( m in messages ){
 				if (messages.hasOwnProperty(m)){
 					if (m.match(new RegExp("^" + value + "\\."))) {
@@ -274,5 +274,7 @@ https://github.com/mroderick/PubSubJS
 
 		return result;
 	};
+
+
 
 }));

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -122,6 +122,25 @@ https://github.com/mroderick/PubSubJS
 		}
 		return true;
 	}
+  
+  /**
+   * Decides if topic string has childs in messages
+   * @param  {String}  topic 
+   * @return {Boolean}      
+   */
+	function isParentTopic (topic){
+		var m, reg = new RegExp("^" + topic + "\\.");
+
+		for ( m in messages ){
+			if (messages.hasOwnProperty(m)){
+				if (reg.test(m)) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
 
 	/**
 	 *	PubSub.publish( message[, data] ) -> Boolean
@@ -204,13 +223,27 @@ https://github.com/mroderick/PubSubJS
 	 *
 	 *		// Example 3 - unsubscribing a topic
 	 *		PubSub.unsubscribe('mytopic');
+	 *		
+	 *		// Example 4 - unsubscribing all children of a parent topic
+	 *		PubSub.unsubscribe('mytopic');
 	 */
 	PubSub.unsubscribe = function(value){
 		var isTopic    = typeof value === 'string' && messages.hasOwnProperty(value),
+			isParent = typeof value === 'string' && isParentTopic(value),
 			isToken    = !isTopic && typeof value === 'string',
 			isFunction = typeof value === 'function',
 			result = false,
 			m, message, t;
+
+		if (isParent) {
+			for ( m in messages ){
+				if (messages.hasOwnProperty(m)){
+					if (m.match(new RegExp("^" + value + "\\."))) {
+						delete messages[m];
+					}
+				}
+			}
+		}
 
 		if (isTopic){
 			delete messages[value];
@@ -241,4 +274,5 @@ https://github.com/mroderick/PubSubJS
 
 		return result;
 	};
+
 }));

--- a/test/test-issue-76.js
+++ b/test/test-issue-76.js
@@ -1,0 +1,40 @@
+(function( global ){
+	"use strict";
+
+	var PubSub = global.PubSub || require("../src/pubsub"),
+		TestHelper = global.TestHelper || require("../test/helper"),
+        assert = buster.assert;
+
+	buster.testCase( "Hierarchical addressing", {
+
+		setUp : function(){
+			this.clock = this.useFakeTimers();
+		},
+
+		tearDown: function(){
+			this.clock.restore();
+		},
+
+		"unsubscribe method should unsubscribe a child and all its successors" : function( done ){
+			var data = TestHelper.getUniqueString(),
+				spy = this.spy(),
+				messages = ['sequence', 'sequence.channel', 'sequence.channel.step'];
+
+			PubSub.subscribe( messages[0], spy ); //This should be called
+			PubSub.subscribe( messages[1], spy ); //Gets unsubscribed
+			PubSub.subscribe( messages[2], spy ); //This should be called
+
+			PubSub.unsubscribe( messages[1], true );
+
+			PubSub.publish( messages[2], data );
+
+			this.clock.tick(1);
+			assert.equals( spy.callCount, 1 );
+
+			done();
+		}
+
+	});
+
+}(this));
+


### PR DESCRIPTION
Implement clearing subscriptions by topic parent like this (before it was not working):

```javascript
PubSub.subscribe('a', myFunc1);
PubSub.subscribe('a.b', myFunc2);
PubSub.subscribe('a.b.c', myFunc3);

PubSub.unsubscribe('a.b');
// no further notications for 'a.b' and 'a.b.c' topics
// notifications for 'a' will still get published
```