### PR TITLE
Expose PubSub factory

### DIFF
--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -21,7 +21,7 @@ https://github.com/mroderick/PubSubJS
         root.PubSub = PubSub;
         factory(PubSub);
     }
-}(( typeof window === 'object' && window ) || this, function (PubSub){
+}(( typeof window === 'object' && window ) || this, function PubSubFactory(PubSub){
 	'use strict';
 
 	var messages = {},
@@ -178,7 +178,7 @@ https://github.com/mroderick/PubSubJS
 	/*Public: Clear subscriptions by the topic
 	*/
 	PubSub.clearSubscriptions = function clearSubscriptions(topic){
-		var m; 
+		var m;
 		for (m in messages){
 			if (messages.hasOwnProperty(m) && m.indexOf(topic) === 0){
 				delete messages[m];
@@ -241,4 +241,9 @@ https://github.com/mroderick/PubSubJS
 
 		return result;
 	};
+
+	/*Public: Creates new PubSub instance.
+	*/
+	PubSub.factory = PubSubFactory;
+
 }));

--- a/test/test-exposing-factory.js
+++ b/test/test-exposing-factory.js
@@ -1,0 +1,31 @@
+(function( global ){
+	"use strict";
+
+	var PubSub = global.PubSub || require("../src/pubsub"),
+        assert = buster.assert;
+
+	buster.testCase( "expose PubSub factory", {
+
+		"should expose PubSub factory" : function( done ){
+			var subscriber1 = this.spy(),
+				subscriber2 = this.spy(),
+				newPubSub = {},
+				clock = this.useFakeTimers();
+
+			PubSub.factory( newPubSub );
+
+			PubSub.subscribe( 'a', subscriber1 );
+			newPubSub.subscribe( 'a', subscriber2 );
+
+			newPubSub.publish( 'a' );
+
+			clock.tick(1);
+
+			assert( !subscriber1.called );
+			assert( subscriber2.calledOnce );
+
+			done();
+			clock.restore();
+		}
+	});
+}(this));


### PR DESCRIPTION
Add an accessible reference to factory (PubSub.factory) to be possible to create new instances. This is intended to be used to write fully isolated unit tests.