### PR TITLE
Replace $.error on duplicated initialization

### DIFF
--- a/wrappers/jquery/pubsub.js.post.txt
+++ b/wrappers/jquery/pubsub.js.post.txt
@@ -1,6 +1,6 @@
 
 	if ( $.pubsub ){
-		$.error( 'pubsub is already defined on jQuery, skipping integration of PubSubJS' );
+		console.warn( 'pubsub is already defined on jQuery, skipping integration of PubSubJS' );
 		return false;
 	}
 


### PR DESCRIPTION
$.error() is deprecated since jQuery 1.8, which will raise an Error and hence halt JS execution. Suggest we use console.warn() instead.
