### PR TITLE
Unsubscribe not removing hierarchy

### DIFF
--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -21,7 +21,7 @@ https://github.com/mroderick/PubSubJS
     var PubSub = {};
     root.PubSub = PubSub;
     factory(PubSub);
-    
+
 }(( typeof window === 'object' && window ) || this, function (PubSub){
 	'use strict';
 
@@ -179,7 +179,7 @@ https://github.com/mroderick/PubSubJS
 	/*Public: Clear subscriptions by the topic
 	*/
 	PubSub.clearSubscriptions = function clearSubscriptions(topic){
-		var m; 
+		var m;
 		for (m in messages){
 			if (messages.hasOwnProperty(m) && m.indexOf(topic) === 0){
 				delete messages[m];
@@ -214,7 +214,7 @@ https://github.com/mroderick/PubSubJS
 			m, message, t;
 
 		if (isTopic){
-			delete messages[value];
+			PubSub.clearSubscriptions(value);
 			return;
 		}
 

--- a/test/test-unsubscribe.js
+++ b/test/test-unsubscribe.js
@@ -115,7 +115,7 @@
 
 			PubSub.unsubscribe(topicB);
 
-			PubSub.publishSync(topicA, TestHelper.getUniqueString());
+			PubSub.publishSync(topicC, TestHelper.getUniqueString());
 
 			assert(spyA.called);
 			refute(spyB.called);


### PR DESCRIPTION
I noticed that the following example did not function as stated. I looked into the issue and found that only the topic with an exact match was removed. Then I looked into why the unit tests were passing and noticed the publish was occurring on the wrong topic to test that the hierarchy had been removed.

```
PubSub.subscribe('a', myFunc1);
PubSub.subscribe('a.b', myFunc2);
PubSub.subscribe('a.b.c', myFunc3);

PubSub.unsubscribe('a.b');
// no further notications for 'a.b' and 'a.b.c' topics
// notifications for 'a' will still get published
```