### PR TITLE
Top level subscriptions (and their descendant topics) are cleared correctly

### DIFF
--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -207,7 +207,18 @@ https://github.com/mroderick/PubSubJS
 	 *		PubSub.unsubscribe('mytopic');
 	 */
 	PubSub.unsubscribe = function(value){
-		var isTopic    = typeof value === 'string' && messages.hasOwnProperty(value),
+		var descendantTopicExists = function(topic) {
+				var m;
+				for ( m in messages ){
+					if ( messages.hasOwnProperty(m) && m.indexOf(topic) === 0 ){
+						// a descendant of the topic exists:
+						return true;
+					}
+				}
+
+				return false;
+			},
+			isTopic    = typeof value === 'string' && ( messages.hasOwnProperty(value) || descendantTopicExists(value) ),
 			isToken    = !isTopic && typeof value === 'string',
 			isFunction = typeof value === 'function',
 			result = false,

--- a/test/test-unsubscribe.js
+++ b/test/test-unsubscribe.js
@@ -122,6 +122,28 @@
 			refute(spyC.called);
 		},
 
+		'with parent topic argument, must clear all child subscriptions': function() {
+			var topic = TestHelper.getUniqueString(),
+				topicA = topic + '.a',
+				topicB = topic + '.a.b',
+				topicC = topic + '.a.b.c',
+				spyB = sinon.spy(),
+				spyC = sinon.spy();
+
+			// subscribe only to  children:
+			PubSub.subscribe(topicB, spyB);
+			PubSub.subscribe(topicC, spyC);
+
+			// but unsubscribe from a parent:
+			PubSub.unsubscribe(topicA);
+
+			PubSub.publishSync(topicB, TestHelper.getUniqueString());
+			PubSub.publishSync(topicC, TestHelper.getUniqueString());
+
+			refute(spyB.called);
+			refute(spyC.called);
+		},
+
 		'must not throw exception when unsubscribing as part of publishing' : function(){
 			refute.exception(function(){
 				var topic = TestHelper.getUniqueString(),


### PR DESCRIPTION
The `unsubscribe` function was ascertaining whether its parameter existed in the `messages` object and was of type string. This check was not enough for scenarios (as described in #106) where only descendant subscriptions were registered and a 'parent' subscription was unsubscribed.

I have added a new `descendantTopicExists` function which checks whether the supplied topic has any descendant subscriptions. A `.` is appended to the parameter so that descendants are correctly identified.

This function is then called to determine the `isTopic` value and if so, processing is handed over to the (untouched in this PR) `clearSubscriptions` function.

This code change fixes the breaking test in 5832fea.