### PR TITLE
ensure hasOwnProperty call is safe (fixes #115)

### DIFF
--- a/test/test-jquery-integration.js
+++ b/test/test-jquery-integration.js
@@ -55,6 +55,23 @@
 			$.pubsub( 'publishSync', topic, data );
 
 			assert( mock.verify() );
+		},
+
+		"$.pubsub('subscribe') should still call subscribe when PubSub.hasOwnProperty has been overridden" : function(){
+			try {
+				var topic = TestHelper.getUniqueString(),
+					spy = this.spy(),
+					mock = this.mock( PubSub );
+
+				mock.expects('subscribe').once().withArgs( topic, spy );
+
+				PubSub.hasOwnProperty = function(){ return false; };
+				$.pubsub('subscribe', topic, spy);
+
+				assert( mock.verify() );
+			} finally {
+				delete PubSub.hasOwnProperty;
+			}
 		}
 	});
 }(this));

--- a/wrappers/jquery/pubsub.js.post.txt
+++ b/wrappers/jquery/pubsub.js.post.txt
@@ -16,7 +16,7 @@
 	}
 
 	function pubsub( method ){
-		if ( PubSub.hasOwnProperty( method ) && typeof PubSub[ method ] === 'function' ){
+		if ( Object.prototype.hasOwnProperty.call( PubSub, method ) && typeof PubSub[ method ] === 'function' ){
 			return PubSub[ method ].apply( self, Array.prototype.slice.call( arguments, 1 ) );
 		}
 


### PR DESCRIPTION
Since the hasOwnProperty function can be overridden on individual
objects, it's recommended to call the function on the prototype
directly. Refer https://github.com/mroderick/PubSubJS/issues/115

Note that the `hasOwnProperty` calls within src/pubsub.js are safe, since the `messages` object is not publicly accessible. 