### PR TITLE
enhance subscribeOnce

### DIFF
--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -204,7 +204,7 @@
 
             func.apply( this, arguments );
         });
-        return token;
+        return PubSub;
     };
 
     /**

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -279,7 +279,7 @@
 
                 if ( isToken && message[value] ){
                     delete message[value];
-                    result = true;
+                    result = value;
                     // tokens are unique, so we can just stop here
                     break;
                 }

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -193,7 +193,7 @@
      * @alias subscribeOnce
      * @param { String } message The message to subscribe to
      * @param { Function } func The function to call when a new message is published
-     * @return { token }
+     * @return { PubSub }
      */
     PubSub.subscribeOnce = function( message, func ){
         var token = PubSub.subscribe( message, function(){

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -198,7 +198,10 @@
     PubSub.subscribeOnce = function( message, func ){
         var token = PubSub.subscribe( message, function(){
             // before func apply, unsubscribe message
-            if(!PubSub.unsubscribe( token )) return;
+            if( !PubSub.unsubscribe( token ) ){
+                return PubSub;
+            }
+
             func.apply( this, arguments );
         });
         return token;
@@ -269,8 +272,7 @@
 
         if (isTopic){
             PubSub.clearSubscriptions(value);
-            result = true;
-            return result;
+            return;
         }
 
         for ( m in messages ){

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -193,15 +193,15 @@
      * @alias subscribeOnce
      * @param { String } message The message to subscribe to
      * @param { Function } func The function to call when a new message is published
-     * @return { PubSub }
+     * @return { token }
      */
     PubSub.subscribeOnce = function( message, func ){
         var token = PubSub.subscribe( message, function(){
             // before func apply, unsubscribe message
-            PubSub.unsubscribe( token );
+            if(!PubSub.unsubscribe( token )) return;
             func.apply( this, arguments );
         });
-        return PubSub;
+        return token;
     };
 
     /**
@@ -269,7 +269,8 @@
 
         if (isTopic){
             PubSub.clearSubscriptions(value);
-            return;
+            result = true;
+            return result;
         }
 
         for ( m in messages ){
@@ -278,7 +279,7 @@
 
                 if ( isToken && message[value] ){
                     delete message[value];
-                    result = value;
+                    result = true;
                     // tokens are unique, so we can just stop here
                     break;
                 }

--- a/test/test-subscribeOnce.js
+++ b/test/test-subscribeOnce.js
@@ -8,6 +8,13 @@ var PubSub = require('../src/pubsub'),
 
 describe( 'subscribeOnce method', function() {
 
+    it( 'should return PubSub', function() {
+        var func = function(){ return undefined; },
+            message = TestHelper.getUniqueString(),
+            pubSub = PubSub.subscribeOnce( message , func );
+        assert.same( pubSub, PubSub );
+    } );
+
     it( 'must be executed only once', function() {
 
         var topic = TestHelper.getUniqueString(),
@@ -20,6 +27,18 @@ describe( 'subscribeOnce method', function() {
 
         assert( spy.calledOnce );
 
+    } );
+
+    it( 'cancellation should be possible', function() {
+
+        var  message = TestHelper.getUniqueString(),
+            spy = sinon.spy();
+
+        PubSub.subscribeOnce( message , spy );
+        
+        PubSub.publish(message, 'my payload');
+
+        assert.same( spy.callCount, 0 );
     } );
 
 } );

--- a/test/test-subscribeOnce.js
+++ b/test/test-subscribeOnce.js
@@ -8,13 +8,6 @@ var PubSub = require('../src/pubsub'),
 
 describe( 'subscribeOnce method', function() {
 
-    it( 'should return PubSub', function() {
-        var func = function(){ return undefined; },
-            message = TestHelper.getUniqueString(),
-            pubSub = PubSub.subscribeOnce( message , func );
-        assert.same( pubSub, PubSub );
-    } );
-
     it( 'must be executed only once', function() {
 
         var topic = TestHelper.getUniqueString(),

--- a/test/test-subscribeOnce.js
+++ b/test/test-subscribeOnce.js
@@ -35,8 +35,8 @@ describe( 'subscribeOnce method', function() {
             spy = sinon.spy();
 
         PubSub.subscribeOnce( message , spy );
-        
-        PubSub.publish(message, 'my payload');
+        PubSub.unsubscribe( message );
+        PubSub.publish( message, 'my payload' );
 
         assert.same( spy.callCount, 0 );
     } );


### PR DESCRIPTION
In the past, subscribeOnce was launched, even though we removed the token with unsubscribe.

Even in the following cases, it has been published.
So I asked for 'pull request' :)

```js
function test(msg, data) {
  console.log('data', msg, data)
} 
const token = PubSub.subscribeOnce('test', test)

const a = PubSub.unsubscribe(token1);
PubSub.publish('test', 'hello');
```