### PR TITLE
Upgrade node on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,13 @@ cache:
 
 matrix:
   include:
-    - node_js: "6"
     - node_js: "8"
+    - node_js: "10"
       before_install: npm install coveralls
       before_script: npm run lint
-      after_success: npm run coverage && cat ./coverage/lcov.info | coveralls lib; 
-    - node_js: "10"
-    - node_js: "node"    
+      after_success: npm run coverage && cat ./coverage/lcov.info | coveralls lib;
+    - node_js: "12"
+    - node_js: "node"
 
 git:
   depth: 10


### PR DESCRIPTION
This PR upgrades node on Travis.

* Stop testing in 6
* Start testing in 12

This will allow #166 to be merged, as Mocha 7 drops support for Node 6