### PR TITLE
fix amd module export

### DIFF
--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -7,26 +7,24 @@
 
 (function (root, factory){
     'use strict';
-
+    
     var PubSub = {};
     root.PubSub = PubSub;
-
     factory(PubSub);
-
-    // AMD support
-    /* eslint-disable no-undef */
-    if (typeof define === 'function' && define.amd){
-        define(function() { return PubSub; });
-        /* eslint-enable no-undef */
-
-        // CommonJS and Node.js module support
-    } else if (typeof exports === 'object'){
+    // CommonJS and Node.js module support
+    if (typeof exports === 'object'){
         if (module !== undefined && module.exports) {
             exports = module.exports = PubSub; // Node.js specific `module.exports`
         }
         exports.PubSub = PubSub; // CommonJS module 1.1.1 spec
         module.exports = exports = PubSub; // CommonJS
     }
+    // AMD support
+    /* eslint-disable no-undef */
+    else if (typeof define === 'function' && define.amd){
+        define(function() { return PubSub; });
+        /* eslint-enable no-undef */
+    } 
 
 }(( typeof window === 'object' && window ) || this, function (PubSub){
     'use strict';

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -8,14 +8,22 @@
 (function (root, factory){
     'use strict';
 
-    if(typeof exports === 'object' && typeof module === 'object')
-		module.exports = factory();
-	else if(typeof define === 'function' && define.amd)
-		define(factory);
-	else {
-		var a = typeof exports === 'object' ? factory() : factory(root);
-		for(var i in a) (typeof exports === 'object' ? exports : root)[i] = a[i];
-	}
+    var define = root.define;
+
+    // AMD support
+    if (typeof define === 'function' && define.amd){
+        define(factory);
+
+        // CommonJS and Node.js module support
+    } else if (typeof exports === 'object'){
+        if (module !== undefined && module.exports) {
+            exports = module.exports = factory(); // Node.js specific `module.exports`
+        }
+        exports.PubSub = PubSub; // CommonJS module 1.1.1 spec
+        module.exports = exports = factory(); // CommonJS
+    }
+
+    root.PubSub = factory();
 
 }(( typeof window === 'object' && window ) || this, function (){
     'use strict';

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -14,8 +14,10 @@
     factory(PubSub);
 
     // AMD support
+    // eslint-disable no-undef
     if (typeof define === 'function' && define.amd){
         define(function() { return PubSub; });
+        // eslint-enable no-undef
 
         // CommonJS and Node.js module support
     } else if (typeof exports === 'object'){

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -14,10 +14,10 @@
     factory(PubSub);
 
     // AMD support
-    // eslint-disable no-undef
+    /* eslint-disable no-undef */
     if (typeof define === 'function' && define.amd){
         define(function() { return PubSub; });
-        // eslint-enable no-undef
+        /* eslint-enable no-undef */
 
         // CommonJS and Node.js module support
     } else if (typeof exports === 'object'){

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -8,8 +8,6 @@
 (function (root, factory){
     'use strict';
 
-    var define = root.define;
-
     // AMD support
     if (typeof define === 'function' && define.amd){
         define(factory);

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -8,28 +8,19 @@
 (function (root, factory){
     'use strict';
 
-    var PubSub = {};
-    root.PubSub = PubSub;
+    if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define(factory);
+	else {
+		var a = typeof exports === 'object' ? factory() : factory(root);
+		for(var i in a) (typeof exports === 'object' ? exports : root)[i] = a[i];
+	}
 
-    var define = root.define;
-
-    factory(PubSub);
-
-    // AMD support
-    if (typeof define === 'function' && define.amd){
-        define(function() { return PubSub; });
-
-        // CommonJS and Node.js module support
-    } else if (typeof exports === 'object'){
-        if (module !== undefined && module.exports) {
-            exports = module.exports = PubSub; // Node.js specific `module.exports`
-        }
-        exports.PubSub = PubSub; // CommonJS module 1.1.1 spec
-        module.exports = exports = PubSub; // CommonJS
-    }
-
-}(( typeof window === 'object' && window ) || this, function (PubSub){
+}(( typeof window === 'object' && window ) || this, function (){
     'use strict';
+
+    var PubSub = {};
 
     var messages = {},
         lastUid = -1,
@@ -347,4 +338,6 @@
 
         return result;
     };
+
+    return PubSub;
 }));

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -8,25 +8,26 @@
 (function (root, factory){
     'use strict';
 
+    var PubSub = {};
+    root.PubSub = PubSub;
+
+    factory(PubSub);
+
     // AMD support
     if (typeof define === 'function' && define.amd){
-        define(factory);
+        define(function() { return PubSub; });
 
         // CommonJS and Node.js module support
     } else if (typeof exports === 'object'){
         if (module !== undefined && module.exports) {
-            exports = module.exports = factory(); // Node.js specific `module.exports`
+            exports = module.exports = PubSub; // Node.js specific `module.exports`
         }
         exports.PubSub = PubSub; // CommonJS module 1.1.1 spec
-        module.exports = exports = factory(); // CommonJS
+        module.exports = exports = PubSub; // CommonJS
     }
 
-    root.PubSub = factory();
-
-}(( typeof window === 'object' && window ) || this, function (){
+}(( typeof window === 'object' && window ) || this, function (PubSub){
     'use strict';
-
-    var PubSub = {};
 
     var messages = {},
         lastUid = -1,
@@ -344,6 +345,4 @@
 
         return result;
     };
-
-    return PubSub;
 }));


### PR DESCRIPTION
I had the same issue with using pubsub-js together with webpack as this guy here:

https://stackoverflow.com/questions/54857046/pubsub-js-cannot-access-functions

So I played around the module export header stuff in pubsub. The problem I identified is, that in the context of webpack there is no window object, so the current implementation in pubsub then falls back to `this`. But AMD `define` is not available in this, but rather in the global context. So the line `define = root.define` effectively kills it in the context of webpack. When I deleted that line, pubsub-js started to work again in the webpack context.