### PR TITLE
Symbols fix

### DIFF
--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -125,8 +125,6 @@
     }
 
     function publish( message, data, sync, immediateExceptions ){
-        message = (typeof message === 'symbol') ? message.toString() : message;
-
         var deliver = createDeliveryFunction( message, data, immediateExceptions ),
             hasSubscribers = messageHasSubscribers( message );
 
@@ -178,8 +176,6 @@
         if ( typeof func !== 'function'){
             return false;
         }
-
-        message = (typeof message === 'symbol') ? message.toString() : message;
 
         // message is not registered yet
         if ( !Object.prototype.hasOwnProperty.call( messages, message ) ){

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -144,7 +144,7 @@
      * Publishes the message, passing the data to it's subscribers
      * @function
      * @alias publish
-     * @param { String } message The message to publish
+     * @param { String | Symbol } message The message to publish
      * @param {} data The data to pass to subscribers
      * @return { Boolean }
      */
@@ -156,7 +156,7 @@
      * Publishes the message synchronously, passing the data to it's subscribers
      * @function
      * @alias publishSync
-     * @param { String } message The message to publish
+     * @param { String | Symbol } message The message to publish
      * @param {} data The data to pass to subscribers
      * @return { Boolean }
      */
@@ -168,7 +168,7 @@
      * Subscribes the passed function to the passed message. Every returned token is unique and should be stored if you need to unsubscribe
      * @function
      * @alias subscribe
-     * @param { String } message The message to subscribe to
+     * @param { String | Symbol } message The message to subscribe to
      * @param { Function } func The function to call when a new message is published
      * @return { String }
      */
@@ -199,7 +199,7 @@
      * Subscribes the passed function to the passed message once
      * @function
      * @alias subscribeOnce
-     * @param { String } message The message to subscribe to
+     * @param { String | Symbol } message The message to subscribe to
      * @param { Function } func The function to call when a new message is published
      * @return { PubSub }
      */

--- a/test/test-symbol.js
+++ b/test/test-symbol.js
@@ -18,4 +18,19 @@ describe( 'subscribe and publish', function() {
         
         assert( PubSub.publish( MESSAGE ), true );
     });
+    it("should call func1 only once", function () {
+        var MESSAGE1 = Symbol("MESSAGE");
+        var MESSAGE2 = Symbol("MESSAGE");
+        var count = 0;
+        var func1 = function (msg) {
+            count++;
+            assert(count === 1, true);
+            return undefined;
+        };
+
+        PubSub.subscribe(MESSAGE1, func1);
+
+        PubSub.publish(MESSAGE1);
+        PubSub.publish(MESSAGE2);
+    });
 });


### PR DESCRIPTION
### Description

Symbol message is converted to string, this behavior make uselles using symbols. Because symbols are not strings, and every symbol is unique `Symbol("message") !== Symbol("message")`.

### What is the purpose of this pull request?
- [x] Bug fix

### Reproduction

Next code will call `func1` twice. This is unexpecte behavior, `func1` must be called only once.
```
        var MESSAGE1 = Symbol("MESSAGE");
        var MESSAGE2 = Symbol("MESSAGE");

        var func1 = function (msg) {
            return undefined;
        };

        PubSub.subscribe(MESSAGE1, func1);

        PubSub.publish(MESSAGE1);
        PubSub.publish(MESSAGE2);
```
