### PR TITLE
Taking the existing root.pubSub is already present

### DIFF
--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -9,11 +9,11 @@
     'use strict';
 
     var PubSub = {};
-    /* If PubSub event is passed from another app, then root.PubSub will already be present and we can assign that to PubSub variable.
-    If root.PubSub is not present, then we can apply the empty object(var PubSub = {}) to root.PubSub */
+
     if (root.PubSub) {
-        PubSub = root.PubSub
-    } else{
+        PubSub = root.PubSub;
+        console.warn("PubSub already loaded, using existing version");
+    } else {
         root.PubSub = PubSub;
         factory(PubSub);
     }

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -9,8 +9,14 @@
     'use strict';
 
     var PubSub = {};
-    root.PubSub = PubSub;
-    factory(PubSub);
+    /* If PubSub event is passed from another app, then root.PubSub will already be present and we can assign that to PubSub variable.
+    If root.PubSub is not present, then we can apply the empty object(var PubSub = {}) to root.PubSub */
+    if (root.PubSub) {
+        PubSub = root.PubSub
+    } else{
+        root.PubSub = PubSub;
+        factory(PubSub);
+    }
     // CommonJS and Node.js module support
     if (typeof exports === 'object'){
         if (module !== undefined && module.exports) {


### PR DESCRIPTION
I am using micro front end architecture where we have an ember app and react app co-existing together in a single page. In both the repos, I have pubsub-js installed. When I try to subscribe and publish events in a single app, I am able to do it. But when I subscribe event from one app and want to receive and publish the same event from another app, I am not able to do that.

**Reason:**
The reason is that we are overriding root.PubSub = {}. When one app is and run, PubSub will be registered in its root. And when the second app gets loaded in the page, it will already have PubSub along with its subscribed events. But when PubSub JS of the second app is loaded, we are making root.PubSub = {} and the root is overridden here. The subscribed event will not be present since we are overriding the existing root.PubSub with empty object. We have to maintain the root.PubSub if it's already present and not override.

**Example:**
_React App:_
PubSub.subscribe('main-theme-event', mainThemeChangedCallback);
_Ember App:_
PubSub.publish('main-theme-event', { data: value });

Here, the subscribed 'main-theme-event' is not received in Ember app.

**Suggested Fix:**
We have to check whether root.PubSub is already present. If it is present, we can apply that or else assign empty PubSub and make factory(PubSub).
**Existing Code:**
var PubSub = {};
root.PubSub = PubSub;
factory(PubSub);

**Suggested Code change:**
var PubSub = {};
if (root.PubSub) {
       PubSub = root.PubSub
} else{
       root.PubSub = PubSub;
       factory(PubSub);
}

Tried this in my project and I am able to make it work. With this change, you can pass events from one app to another along with the existing behaviour. By doing this, we are not overrididing the existing PubSub that is already present in root.