### PR TITLE
Show console.warn only in production

### DIFF
--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -12,7 +12,10 @@
 
     if (root.PubSub) {
         PubSub = root.PubSub;
-        console.warn("PubSub already loaded, using existing version");
+        
+        if(process && process.env && process.env.NODE_ENV !== 'production'){
+            console.warn('PubSub already loaded, using existing version');
+        }
     } else {
         root.PubSub = PubSub;
         factory(PubSub);


### PR DESCRIPTION
make console.warn optional reading NODE_ENV variable (if exists). Show console.warn only in production. 

The problem is that we log all console stuff to the logger and now we got thousands of useless messages there