### PR TITLE
fix: add optional environment variable to disable console.warn

### DIFF
--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -12,7 +12,9 @@
 
     if (root.PubSub) {
         PubSub = root.PubSub;
-        console.warn("PubSub already loaded, using existing version");
+        if (!process.env.PUBSUBJS_DISABLE_EXISTING_VERSION_WARNING) {
+            console.warn("PubSub already loaded, using existing version");
+        }
     } else {
         root.PubSub = PubSub;
         factory(PubSub);


### PR DESCRIPTION
Follow-up PR from the following issue: https://github.com/mroderick/PubSubJS/pull/220

Allows consumers to optionally disable the `console.warn("PubSub already loaded, using existing version");` with an `PUBSUBJS_DISABLE_EXISTING_VERSION_WARNING` environment variable.